### PR TITLE
Changed to Flask-SecurityToo and updated role

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -7,7 +7,7 @@ windows:
       layout: main-horizontal
       panes:
         - services:
-          - docker-compose up database redis
+          - docker compose up database redis
         - celery:
           - export export FLASK_DEBUG=1
           - export export ENVIRONMENT=dev

--- a/ccrew/config.py
+++ b/ccrew/config.py
@@ -40,6 +40,8 @@ class Config:
     SECURITY_PASSWORD_SALT = os.environ.get(
         "SECURITY_PASSWORD_SALT", "security password salt <keep secret>"
     )
+    SECURITY_API_ENABLED = os.environ.get("SECURITY_API_ENABLED", True)
+
     REMEMBER_COOKIE_SAMESITE = "strict"
     SESSION_COOKIE_SAMESITE = "strict"
     SQLALCHEMY_ENGINE_OPTIONS = {

--- a/ccrew/core/auth.py
+++ b/ccrew/core/auth.py
@@ -26,5 +26,9 @@ def seed_auth(security: Security):
             raise ValueError(
                 "Missing user/password to seed, set environment ADMIN_USER and ADMIN_PASSWORD first"
             )
-        security.datastore.create_role(name="admin")
-        security.datastore.create_user(email=user, password=hash_password(password))
+        admin_role = security.datastore.find_or_create_role(name="admin")
+        admin_user = security.datastore.create_user(
+            email=user, password=hash_password(password)
+        )
+        security.datastore.add_role_to_user(admin_user, admin_role)
+        security.datastore.commit()

--- a/env.docker
+++ b/env.docker
@@ -1,3 +1,6 @@
+# The runtime environemt, dev or docker
+ENVIRONMENT=docker
+
 # Database Login
 POSTGRES_DB=ccrew_database
 POSTGRES_USER=user
@@ -9,7 +12,8 @@ AIS_STREAM_API_KEY=<PUT YOUR AIS KEY HERE>
 # Flask-Security-Too settings
 SECRET_KEY=<SECRET KEY>
 SECURITY_PASSWORD_SALT=<SALT>
-ENVIRONMENT=dev
+
+
 
 # Will create this amin user/password if not exists.
 ADMIN_USER=<ADMIN USER EMAIL GOES HERE>

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ Flask-Login==0.6.3
 Flask-Mailman==1.1.1
 Flask-Migrate==4.0.7
 Flask-Principal==0.4.0
-Flask-Security==5.5.2
+Flask-Security-Too==5.6.2
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.2
 flower==2.0.1


### PR DESCRIPTION
Not actually properly fixed but a workaround can be achieved with a browser now (but navigating to /admin/ais/start to initiate a login). Updated to Flask-SecurityToo, but REST API requests to /login still don't work so unable to login using curl only with CSRF errors.